### PR TITLE
Clear errors left over from PR42

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,10 +97,12 @@ class epel (
     }
 
     yumrepo { 'epel':
+      # lint:ignore:selector_inside_resource
       mirrorlist     => $epel_baseurl ? {
         'absent' => $epel_mirrorlist,
         default  => 'absent',
       },
+      # lint:endignore
       baseurl        => $epel_baseurl,
       failovermethod => $epel_failovermethod,
       proxy          => $epel_proxy,
@@ -113,10 +115,12 @@ class epel (
     }
 
     yumrepo { 'epel-debuginfo':
+      # lint:ignore:selector_inside_resource
       mirrorlist     => $epel_debuginfo_baseurl ? {
         'absent' => $epel_debuginfo_mirrorlist,
         default  => 'absent',
       },
+      # lint:endignore
       baseurl        => $epel_debuginfo_baseurl,
       failovermethod => $epel_debuginfo_failovermethod,
       proxy          => $epel_debuginfo_proxy,
@@ -129,10 +133,12 @@ class epel (
     }
 
     yumrepo { 'epel-source':
+      # lint:ignore:selector_inside_resource
       mirrorlist     => $epel_source_baseurl ? {
         'absent' => $epel_source_mirrorlist,
         default  => 'absent',
       },
+      # lint:endignore
       baseurl        => $epel_source_baseurl,
       failovermethod => $epel_source_failovermethod,
       proxy          => $epel_source_proxy,

--- a/spec/classes/epel_spec.rb
+++ b/spec/classes/epel_spec.rb
@@ -31,7 +31,7 @@ describe 'epel' do
       context 'epel_baseurl => https://example.com/epel/7/x87_74' do
         let(:params) {{ :epel_baseurl => "https://example.com/epel/7/x87_74" }}
         it { should contain_yumrepo('epel').with('baseurl' => 'https://example.com/epel/7/x87_74') }
-        it { should contain_yumrepo('epel').with('mirrorlist'  => 'absent') }
+        it { should contain_yumrepo('epel').with('mirrorlist' => 'absent') }
       end
 
       context 'epel_mirrorlist => absent' do
@@ -75,7 +75,7 @@ describe 'epel' do
       context 'epel_baseurl => https://example.com/epel/6/x86_64' do
         let(:params) {{ :epel_baseurl => "https://example.com/epel/6/x86_64" }}
         it { should contain_yumrepo('epel').with('baseurl' => 'https://example.com/epel/6/x86_64') }
-        it { should contain_yumrepo('epel').with('mirrorlist'  => 'absent') }
+        it { should contain_yumrepo('epel').with('mirrorlist' => 'absent') }
       end
 
       context 'epel_mirrorlist => absent' do


### PR DESCRIPTION
  Ignore lint warning about selector.
  Two rspec rubocop errors.