### PR TITLE
Update project url and source to use HTTPS

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,8 +4,8 @@
   "author": "stahnma",
   "summary": "Setup the EPEL package repo",
   "license": "Apache-2.0",
-  "source": "http://github.com/stahnma/puppet-module-epel",
-  "project_page": "http://github.com/stahnma/puppet-module-epel",
+  "source": "https://github.com/stahnma/puppet-module-epel",
+  "project_page": "https://github.com/stahnma/puppet-module-epel",
   "issues_url": "https://github.com/stahnma/puppet-module-epel/issues",
     "operatingsystem_support": [
     {


### PR DESCRIPTION
Git clones of http do not follow the https redirect github provides.