### PR TITLE
(docs) Update comment made in previous commit

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -171,7 +171,7 @@ class epel (
       includepkgs    => $epel_source_includepkgs,
     }
 
-    # ERB template used here to avoid a dependency on a Puppet Master;
+    # ERB template used here to ensure file content is in the Puppet catalog;
     # nothing is interpolated in these templates.
 
     file { "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-${os_maj_release}":


### PR DESCRIPTION
The comment added in the previous commit incorrectly implied that the
file `source => ...` pattern is incompatible with masterless Puppet; in
fact, it turns out that is not so.

Rather than revert, I update the comment to provide a better reason why
templates are nevertheless preferrable to sourced files.