### PR TITLE
Release 1.3.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,32 +1,52 @@
 {
   "name": "stahnma-epel",
-  "version": "1.3.1-rc0",
+  "version": "1.3.1",
   "author": "stahnma",
   "summary": "Setup the EPEL package repo",
   "license": "Apache-2.0",
   "source": "https://github.com/stahnma/puppet-module-epel",
   "project_page": "https://github.com/stahnma/puppet-module-epel",
   "issues_url": "https://github.com/stahnma/puppet-module-epel/issues",
-    "operatingsystem_support": [
+  "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
-      "operatingsystemrelease": [ "5", "6", "7" ]
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
     },
     {
       "operatingsystem": "CentOS",
-      "operatingsystemrelease": [ "5", "6", "7" ]
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
     },
     {
       "operatingsystem": "Scientific",
-      "operatingsystemrelease": [ "5", "6", "7" ]
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
     },
     {
       "operatingsystem": "OEL",
-      "operatingsystemrelease": [ "5", "6", "7" ]
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
     },
     {
       "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [ "5", "6", "7" ]
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
     }
   ],
   "requirements": [
@@ -36,5 +56,10 @@
     }
   ],
   "description": "Setup the EPEL package repo on Centos/RHEL et al",
-  "dependencies": [ { "name": "puppetlabs/stdlib", "version_requirement": ">= 3.0.0" } ]
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 3.0.0"
+    }
+  ]
 }


### PR DESCRIPTION
In #74 I left the -rc0 in which breaks the blacksmith workflow.

@stahnma after completion, it needs a `rake module:release` from you, as I don't have access to your namespace on the forge. Sorry, I got so used to working on VP modules I thought I could do that for you :(