### PR TITLE
Adjust gpg args to account for slightly different display.

### DIFF
--- a/manifests/rpm_gpg_key.pp
+++ b/manifests/rpm_gpg_key.pp
@@ -21,7 +21,7 @@ define epel::rpm_gpg_key($path) {
   exec {  "import-${name}":
     path      => '/bin:/usr/bin:/sbin:/usr/sbin',
     command   => "rpm --import ${path}",
-    unless    => "rpm -q gpg-pubkey-$(echo $(gpg --throw-keyids --keyid-format short < ${path}) | cut --characters=11-18 | tr '[A-Z]' '[a-z]')",
+    unless    => "rpm -q gpg-pubkey-$(echo $(gpg -q --throw-keyids --keyid-format short < ${path}) | grep pub | cut -f2 -d/ | cut -f1 -d' ' | tr '[A-Z]' '[a-z]')",
     require   => File[$path],
     logoutput => 'on_failure',
   }

--- a/spec/defines/rpm_gpg_key_spec.rb
+++ b/spec/defines/rpm_gpg_key_spec.rb
@@ -23,7 +23,7 @@ describe 'epel::rpm_gpg_key' do
       is_expected.to contain_exec("import-#{title}").with(
         path:      '/bin:/usr/bin:/sbin:/usr/sbin',
         command:   "rpm --import #{params[:path]}",
-        unless:    "rpm -q gpg-pubkey-$(echo $(gpg --throw-keyids --keyid-format short < #{params[:path]}) | cut --characters=11-18 | tr '[A-Z]' '[a-z]')",
+        unless:    "rpm -q gpg-pubkey-$(echo $(gpg -q --throw-keyids --keyid-format short < #{params[:path]}) | grep pub | cut -f2 -d/ | cut -f1 -d' ' | tr '[A-Z]' '[a-z]')",
         require:   "File[#{params[:path]}]",
         logoutput: 'on_failure'
       )
@@ -52,7 +52,7 @@ describe 'epel::rpm_gpg_key' do
       is_expected.to contain_exec("import-#{title}").with(
         path:      '/bin:/usr/bin:/sbin:/usr/sbin',
         command:   "rpm --import #{params[:path]}",
-        unless:    "rpm -q gpg-pubkey-$(echo $(gpg --throw-keyids --keyid-format short < #{params[:path]}) | cut --characters=11-18 | tr '[A-Z]' '[a-z]')",
+        unless:    "rpm -q gpg-pubkey-$(echo $(gpg -q --throw-keyids --keyid-format short < #{params[:path]}) | grep pub | cut -f2 -d/ | cut -f1 -d' ' | tr '[A-Z]' '[a-z]')",
         require:   "File[#{params[:path]}]",
         logoutput: 'on_failure'
       )
@@ -81,7 +81,7 @@ describe 'epel::rpm_gpg_key' do
       is_expected.to contain_exec("import-#{title}").with(
         path:      '/bin:/usr/bin:/sbin:/usr/sbin',
         command:   "rpm --import #{params[:path]}",
-        unless:    "rpm -q gpg-pubkey-$(echo $(gpg --throw-keyids --keyid-format short < #{params[:path]}) | cut --characters=11-18 | tr '[A-Z]' '[a-z]')",
+        unless:    "rpm -q gpg-pubkey-$(echo $(gpg -q --throw-keyids --keyid-format short < #{params[:path]}) | grep pub | cut -f2 -d/ | cut -f1 -d' ' | tr '[A-Z]' '[a-z]')",
         require:   "File[#{params[:path]}]",
         logoutput: 'on_failure'
       )


### PR DESCRIPTION
This PR updates the gpg call to work with RHEL8.  It adds a -q flag to silence a little warning (no big deal) but more importantly, the key went from being displayed like:

```
pub  4096R/352C64E5 2013-12-16 Fedora EPEL (7) <epel@fedoraproject.org>
```
to

```
pub   rsa4096/352C64E5 2013-12-16 [SCE]
         91E.......not typing this out
uid                                       Fedora EPEL (7) <epel@fedoraproject.org>
```

The PR isolates the pub line, and uses delimiter based cutting to get at the thumbprint we are looking for.

Note: I realize EPEL is not really ready for 8 yet, but I'm currently fudging it a bit by pointing 8 at 7.  =)