### PR TITLE
Amazon Linux 2 - bugfix - use enterprise linux 7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,7 +80,7 @@ class epel (
   $epel_gpg_managed                       = $epel::params::epel_gpg_managed,
   $os_maj_release                         = $epel::params::os_maj_release,
 ) inherits epel::params {
-  if "${::osfamily}" == 'RedHat' and "${::operatingsystem}" !~ /Fedora|Amazon/ { # lint:ignore:only_variable_string
+  if "${::osfamily}" == 'RedHat' { # lint:ignore:only_variable_string
   if $epel_testing_managed {
     yumrepo { 'epel-testing':
       # lint:ignore:selector_inside_resource
@@ -229,13 +229,6 @@ class epel (
     }
   }
 
-  } elsif "${::osfamily}" == 'RedHat' and "${::operatingsystem}" == 'Amazon' { # lint:ignore:only_variable_string
-  if $epel_managed {
-    yumrepo { 'epel':
-      enabled  => $epel_enabled,
-      gpgcheck => $epel_gpgcheck,
-    }
-  }
   } else {
     notice ("Your operating system ${::operatingsystem} will not have the EPEL repository applied")
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class epel::params {
   #   the most specific declaration of proxy.
   $proxy = 'absent'
 
-  if "${::osfamily}" == 'RedHat' and "${::operatingsystem}" == 'Amazon' {
+  if "${::operatingsystem}" == 'Amazon' {
     # Amazon Linux 2 is equivalent of Enterprise Linux 7 so we use that version for epel
     # https://aws.amazon.com/premiumsupport/knowledge-center/ec2-enable-epel/
     $os_maj_release = '7'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class epel::params {
   #   the most specific declaration of proxy.
   $proxy = 'absent'
 
-  if "${::operatingsystem}" == 'Amazon' {
+  if "${::operatingsystem}" == 'Amazon' and "${::operatingsystemmajrelease}" == '2'  {
     # Amazon Linux 2 is equivalent of Enterprise Linux 7 so we use that version for epel
     # https://aws.amazon.com/premiumsupport/knowledge-center/ec2-enable-epel/
     $os_maj_release = '7'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,11 +8,17 @@ class epel::params {
   #   the most specific declaration of proxy.
   $proxy = 'absent'
 
-  if getvar('::operatingsystemmajrelease') {
-    $os_maj_release = $::operatingsystemmajrelease
+  if "${::osfamily}" == 'RedHat' and "${::operatingsystem}" == 'Amazon' {
+    # Amazon Linux 2 is equivalent of Enterprise Linux 7 so we use that version for epel
+    # https://aws.amazon.com/premiumsupport/knowledge-center/ec2-enable-epel/
+    $os_maj_release = '7'
   } else {
-    $os_versions    = split("${::operatingsystemrelease}", '[.]') # lint:ignore:only_variable_string
-    $os_maj_release = $os_versions[0]
+    if getvar('::operatingsystemmajrelease') {
+      $os_maj_release = $::operatingsystemmajrelease
+    } else {
+      $os_versions    = split("${::operatingsystemrelease}", '[.]') # lint:ignore:only_variable_string
+      $os_maj_release = $os_versions[0]
+    }
   }
 
   if versioncmp($os_maj_release, '5') > 0 {

--- a/spec/classes/epel_spec.rb
+++ b/spec/classes/epel_spec.rb
@@ -207,17 +207,33 @@ describe 'epel' do
       )
     end
 
-    it { is_expected.not_to contain_yumrepo('epel-testing') }
-    it { is_expected.not_to contain_yumrepo('epel-testing-debuginfo') }
-    it { is_expected.not_to contain_yumrepo('epel-testing-source') }
-    it { is_expected.not_to contain_yumrepo('epel-debuginfo') }
-    it { is_expected.not_to contain_yumrepo('epel-source') }
+    it_behaves_like :base_7
+    it_behaves_like :gpgkey_7
+    it_behaves_like :epel_source_7
+    it_behaves_like :epel_debuginfo_7
+    it_behaves_like :epel_testing_7
+    it_behaves_like :epel_testing_source_7
+    it_behaves_like :epel_testing_debuginfo_7
 
-    it do
-      is_expected.to contain_yumrepo('epel').with(
-        enabled:  '1',
-        gpgcheck: '1'
-      )
+    context 'epel_baseurl => https://example.com/epel/7/x86_64' do
+      let(:params) do
+        {
+          epel_baseurl: 'https://example.com/epel/7/x86_64'
+        }
+      end
+
+      it { is_expected.to contain_yumrepo('epel').with(baseurl: 'https://example.com/epel/7/x86_64') }
+      it { is_expected.to contain_yumrepo('epel').with(mirrorlist: 'absent') }
+    end
+
+    context 'epel_mirrorlist => absent' do
+      let(:params) do
+        {
+          epel_mirrorlist: 'absent'
+        }
+      end
+
+      it { is_expected.to contain_yumrepo('epel').with(mirrorlist: 'absent') }
     end
   end
 end

--- a/spec/classes/epel_spec.rb
+++ b/spec/classes/epel_spec.rb
@@ -202,8 +202,9 @@ describe 'epel' do
   context 'operatingsystem => Amazon' do
     let :facts do
       default_facts.merge(
-        operatingsystem:        'Amazon',
-        operatingsystemrelease: 'Amazon'
+        operatingsystem:            'Amazon',
+        operatingsystemrelease:     'Amazon',
+        operatingsystemmajrelease:  '2'
       )
     end
 


### PR DESCRIPTION
Previously it would throw a `Cannot find a valid baseurl for repo: epel` error as no mirrorlist nor baseurl would be populated for Amazon; this fixes that with the assumption that Amazon Linux 2 uses Enterprise Linux 7 as per AWS docs: 
https://aws.amazon.com/premiumsupport/knowledge-center/ec2-enable-epel/